### PR TITLE
💄 Redesign FAQ page with categories, search and collapsible answers

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -1,76 +1,271 @@
 ---
 title: FAQ
-layout: page
+layout: standard
+description: Answers to common questions about Process PA — pricing, free trial, member access, meetings, minutes, documents and security.
+faq_categories:
+  - id: getting-started
+    title: Getting Started
+  - id: pricing
+    title: Pricing & Billing
+  - id: members
+    title: Members & Access
+  - id: meetings
+    title: Meetings, Agendas & Minutes
+  - id: documents
+    title: Documents, Data & Security
 faq:
-  - question: What is Process PA?
-    answer: Process PA is your personal assistant guiding you through your governance requirements for your management committee or board.
-  - question: How do I get started?
-    answer: You can begin a free 30-day trial by registering at [https://app.processpa.com/authenticate/password-register](https://app.processpa.com/authenticate/password-register). For more details on getting setup go to [Help](/help.html).
-  - question: Do I need all members to agree to move over to Process PA?
-    answer: While we recommend approval from the members in most situations, Process PA has been built in a way that the main user, often the secretary, can take advantage of the improved process using Process PA without changing the process other members are currently doing. Everything can be emailed as it was before (albeit faster with our PDF combining and attachment bundling) so members get all they need in their inbox. They do not even need to log in to the platform at all. That said, if they do there are other benefits like historial access to information that they can take advantage of.
-  - question: How many board and committee members can I add?
-    answer: You can add all your board directors and committee members. We do not charge per user, but keep pricing simple per organization board and committee. You can control if your members have access online, receive content only via email or can modify your content.
-  - question: How do users access Process PA?
-    answer: Process PA is accessible from any browser (e.g. Google Chrome, Microsoft Edge, Firefox) on any device, PC/Mac, Tablet or Phone at [https://app.processpa.com/](https://app.processpa.com/).
-  - question: How can other members login?
-    answer: After you have added the member and set their access level ([Manage Membership](/quick-start-guide/manage-membership)), the user can register with the same email address and log in. Note that on the emails that go out from Process PA contain a link to view online. If the member has created an account this will take them to the register page with their details filled out. All they need to do is set a password.
-  - question: Does the site work offline?
-    answer: Unfortunately no. We have optimized it to use very little data so that it works through mobile data quickly. An internet connection is required while taking minutes though. If a connection can't be obtained for the meeting, taking minutes the traditional way and entering them later into Process PA later still give other benefits of the system, such as distributions, consistency and continuity of records.
-  - question: Can Ordinary Members access documents?
-    answer: Members can be given either Administrator, Viewer or Email Only access. Administrators can modify everything, Viewers can only view everything and Email members only receive content via email. When other members register with Process PA, if they are members of any organizations those will be available for them to access.
-  - question: How can I add executives who are not directors?
-    answer: New roles for members, can be created on the “Settings” page under “Edit Roles”. Simply add or rename a current role. The member’s permission level can then be adjusted within the Members details, in the Members Register. 
-  - question: Deleting and adding members
-    answer: Members can be added, edited or deleted in the Members Register. Click on “Members” in the menu bar at the top of the page. From this page you can add or delete members. Or to Edit, select the “Pencil” icon on the right of the page, next to the member’s name. As an alternative to deleting a member, their permission level may be set to “None” in which they no longer have access, but their details remain in the system. These details can be activated again by simply changing permission levels.
-  - question: How do I change the Agenda Template?
-    answer:  In “Settings” on the left, scroll down until you come to “Agenda Template”. Under “Meeting” select between the meetings types “General”, “Annual” or “Special” Once selected you will be taken to the Agenda template where you can rearrange and edit the Agenda, for all future meetings.
-  - question: How can I create Sub Agenda Items?
-    answer: Sub Agenda Items can be created either in the Notes section of the Agenda Item, or you can use capital letters or brackets to differentiate the different Sub Agenda's. For examples of this, click here [https://processpa.com/quick-start-guide/creating-sub-agendas](https://processpa.com/quick-start-guide/creating-sub-agendas).
-  - question: Can I resize the font used in the Agenda Items?
-    answer: The Font size used in the Agenda, can only be changed within the notes and not in the Agenda Item title.
-  - question: How to remove action items from an agenda.
-    answer: To delete an Action Item from an agenda, open the Action Item and select delete. A pop up will ask you to confirm your choice.
-  - question: Can I send the agenda and the request for attendance out together?
-    answer: When the Agenda is emailed, a link will be included where members can click and record their attendance for the meeting.
-  - question: Add standard motions to meeting template.
-    answer: Standard Motions and Actions can be included in the Agenda Template, which will be generated for each meeting.
-  - question: How do I edit the Roles?
-    answer: In “Settings” on the left, scroll down until you come to “Edit Roles” Here you may add, delete or change the Role titles.  
-  - question: Do the previous meetings minutes, automatically generate onto the next meeting’s agenda?
-    answer: Before a meeting can close, a date for the next meeting must be created. The minutes will automatically be included on the Agenda for that next meeting.
-  - question: How do I change whom the emails come from, for the Agenda’s, Minutes and Request of Attendance?
-    answer: In “Settings” just under the “Page Header” section, is “Email Reply – To Address”. Select from the drop-down menu, who the correspondence is to come from.
-  - question: What if a future committee decide not to continue using Process PA?
-    answer: Everything can be download from Process PA at any time to be put elsewhere.
-  - question: Can emails be sent to just one person?
-    answer: Emails can be sent to as many or as few members as you need. To do this, check boxes will be presented to you within "Emails" located in "Preview Minutes". From here, you can check the boxes of whom you wish to send the emails to before you select “Send”.
-  - question: Can minutes be edited once a meeting is finalised?
-    answer: Minutes from completed meetings can be edited and redistributed, however new Actions Items and/or Motions, cannot be created. Please contact [support@processpa.com](mailto:support@processpa.com) if you need help with this.
-  - question: Can I delete a completed meeting?
-    answer: Completed meetings cannot be deleted by users. Please contact [support@processpa.com](mailto:support@processpa.com) and we will delete the meeting for you.
-  - question: How to reset the clock in a meeting
-    answer: To reset the clock in a meeting, click the reset clock icon (a red cirle with an arrow), that is located just right of the clock. This will reset the meeting time.
-  - question: Can the Time-zone be changed?
-    answer: The Time-zone is set in the initial setup of an organization. To have the Time-zone changed, contact us at [support@processpa.com](mailto:support@processpa.com)
-  - question: Can the document folder be re-arranged from the front end?
-    answer: The Document folder cannot be reorganised. This is a feature that we will look to incorporate in a future update.
-  - question: Are documents that have been uploaded, able to be refiled?
-    answer: Documents are not able to be refiled once uploaded. This is a subject that we will be looking at resolving in the future. To resolve this matter, the user can re-upload the file into the correct folder. If the user does not have the file on their local PC, they can download and save from Process PA onto their PC and upload again. However, once the document has been changed, the new file will not have the connections to previous meetings it was used in.
-
-
+  - category: getting-started
+    question: What is Process PA?
+    answer: Process PA is your personal assistant for good governance — board and committee management software that helps you prepare agendas, take minutes, track motions and action items, and keep your records in order. It is built for Australian associations, not-for-profits and small businesses.
+  - category: getting-started
+    question: How do I get started?
+    answer: You can begin a free 30-day trial — no credit card required — by registering at [https://app.processpa.com/authenticate/password-register](https://app.processpa.com/authenticate/password-register). For more details on getting set up, go to [Help](/help.html), or book our free concierge service and we will set your organization up for you.
+  - category: getting-started
+    question: Do I need all members to agree to move over to Process PA?
+    answer: No. While we recommend approval from the members in most situations, Process PA has been built so that the main user, often the secretary, can take advantage of the improved process without changing what other members currently do. Everything can be emailed as it was before (albeit faster, with our PDF combining and attachment bundling), so members get all they need in their inbox — they do not even need to log in to the platform. That said, if they do, there are other benefits they can take advantage of, like historical access to information.
+  - category: getting-started
+    question: How do users access Process PA?
+    answer: Process PA is accessible from any browser (e.g. Google Chrome, Microsoft Edge, Firefox) on any device — PC, Mac, tablet or phone — at [https://app.processpa.com/](https://app.processpa.com/). There is nothing to install.
+  - category: getting-started
+    question: Does Process PA work offline?
+    answer: Unfortunately no. We have optimized it to use very little data so that it works quickly over mobile data, but an internet connection is required while taking minutes. If a connection can't be obtained for the meeting, taking minutes the traditional way and entering them into Process PA later still gives you the other benefits of the system, such as distribution, consistency and continuity of records.
+  - category: pricing
+    question: How much does Process PA cost?
+    answer: "Plans are priced per organization, not per user: Starter $115/month, Standard $165/month and Enterprise $240/month. All prices are in Australian Dollars and include GST. Every plan starts with a free 30-day trial. See [Pricing](/pricing.html) for full details."
+  - category: pricing
+    question: Do you offer a discount for not-for-profits?
+    answer: Yes. Registered not-for-profits receive 20% off all plans. See [Pricing](/pricing.html) for details.
+  - category: pricing
+    question: Can we pay annually?
+    answer: Yes, and it's rewarded — annual billing gives you 2 months free (pay for 10 months, get 12).
+  - category: pricing
+    question: Can we manage sub-committees in Process PA?
+    answer: Yes. The Standard plan includes 2 sub-committees and the Enterprise plan includes 5. Additional sub-committees can be added to your plan for $65/month each.
+  - category: pricing
+    question: What if a future committee decides not to continue with Process PA?
+    answer: Your records are always yours. Everything can be downloaded from Process PA at any time to be stored or used elsewhere, so you are never locked in.
+  - category: members
+    question: How many board and committee members can I add?
+    answer: You can add all your board directors and committee members. We do not charge per user — pricing is kept simple, per organization board and committee. You control whether each member has online access, receives content only via email, or can modify your content.
+  - category: members
+    question: What access levels can members have?
+    answer: Members can be given Administrator, Viewer or Email Only access. Administrators can modify everything, Viewers can view everything, and Email Only members receive content via email without logging in. When members register with Process PA, any organizations they belong to are available for them to access.
+  - category: members
+    question: How do other members log in?
+    answer: After you have added a member and set their access level ([Manage Membership](/quick-start-guide/manage-membership)), they can register with the same email address and log in. Emails sent from Process PA contain a link to view online — if the member has not yet created an account, this takes them to the register page with their details pre-filled, so all they need to do is set a password.
+  - category: members
+    question: How do I add or remove members?
+    answer: Members can be added, edited or deleted in the Members Register — click "Members" in the menu bar at the top of the page. To edit, select the pencil icon next to the member's name. As an alternative to deleting a member, their permission level may be set to "None" — they no longer have access, but their details remain in the system and can be reactivated later by changing their permission level.
+  - category: members
+    question: Can I create custom roles, such as executives who are not directors?
+    answer: Yes. Roles can be added, renamed or deleted on the "Settings" page under "Edit Roles". A member's role and permission level can then be adjusted within their details in the Members Register.
+  - category: meetings
+    question: How do I change the agenda template?
+    answer: In "Settings", scroll down to "Agenda Template". Under "Meeting", select between the meeting types "General", "Annual" or "Special". Once selected, you will be taken to the agenda template where you can rearrange and edit the agenda for all future meetings.
+  - category: meetings
+    question: Can I add standard motions to the meeting template?
+    answer: Yes. Standard motions and actions can be included in the agenda template, and they will be generated for each meeting.
+  - category: meetings
+    question: How can I create sub agenda items?
+    answer: Sub agenda items can be created either in the notes section of the agenda item, or you can use capital letters or brackets to differentiate the different sub agendas. For examples, see [Creating Sub Agendas](/quick-start-guide/creating-sub-agendas).
+  - category: meetings
+    question: Can I send the agenda and the request for attendance out together?
+    answer: Yes. When the agenda is emailed, a link is included where members can click and record their attendance for the meeting.
+  - category: meetings
+    question: Do the previous meeting's minutes automatically appear on the next agenda?
+    answer: Yes. Before a meeting can close, a date for the next meeting must be set. The minutes are then automatically included on the agenda for that next meeting.
+  - category: meetings
+    question: Can minutes be edited once a meeting is finalised?
+    answer: Minutes from completed meetings can be edited and redistributed; however, new action items and/or motions cannot be created. Please contact [support@processpa.com](mailto:support@processpa.com) if you need help with this.
+  - category: meetings
+    question: Can I delete a completed meeting?
+    answer: Completed meetings cannot be deleted by users — this protects the continuity of your records. Please contact [support@processpa.com](mailto:support@processpa.com) and we will delete the meeting for you.
+  - category: meetings
+    question: How do I remove an action item from an agenda?
+    answer: To delete an action item from an agenda, open the action item and select delete. A pop-up will ask you to confirm your choice.
+  - category: meetings
+    question: Can emails be sent to just some members?
+    answer: Yes. Emails can be sent to as many or as few members as you need. Check boxes are presented within "Emails", located in "Preview Minutes" — check the boxes of whom you wish to send the emails to before you select "Send".
+  - category: meetings
+    question: How do I change who the agenda and minutes emails come from?
+    answer: In "Settings", just under the "Page Header" section, is "Email Reply-To Address". Select from the drop-down menu who the correspondence should come from.
+  - category: documents
+    question: Is our data secure?
+    answer: Yes. Process PA is hosted on Microsoft's world-class cloud platform, Azure. All data is encrypted in transit (HTTPS/SSL) and at rest, access to databases and storage is strictly controlled, and continuous backups are distributed across multiple data centres to prevent loss. Read more on our [Security](/security) page.
+  - category: documents
+    question: Can we export our data?
+    answer: Yes. Everything — minutes, documents and records — can be downloaded from Process PA at any time. Your data always remains yours.
+  - category: documents
+    question: Can documents be moved or reorganised after uploading?
+    answer: Yes. Files can be moved between folders and renamed from the Documents page. See [Move a File](/help/documents/move%20a%20file) in our help documentation.
+  - category: documents
+    question: Can the time zone be changed?
+    answer: The time zone is set in the initial setup of an organization. To have the time zone changed, contact us at [support@processpa.com](mailto:support@processpa.com).
+  - category: documents
+    question: How do I get help or support?
+    answer: Start with our [Help documentation](/help.html) and the [Quick Start Guide](/help.html). You can also reach us via the live chat on this site or by emailing [support@processpa.com](mailto:support@processpa.com) — we're happy to help.
 ---
 
-<div class="container">
-    <section class="faq">
-        <ul>
-            {% for item in page.faq %}
-                <li><a href="#{{ item.question | slugify }}">{{ item.question }}</a></li>
-            {% endfor %}
-        </ul>
+<style>
+/* FAQ items — native <details> styled as cards (no JS needed to open/close,
+   and multiple answers can stay open at once) */
+.faq-item {
+    border: 1px solid #e4e7eb;
+    border-radius: 10px;
+    background: #fff;
+    margin-bottom: 0.75rem;
+    transition: border-color 0.2s, box-shadow 0.2s;
+    scroll-margin-top: 95px; /* clear the fixed navbar on anchor jumps */
+}
 
-        {% for item in page.faq %}
-            <h2 id="{{ item.question | slugify}}">{{ item.question }}<a class="header-link" href="#{{ item.question | slugify }}">#</a></h2>
-            {{ item.answer | markdownify }}
-        {% endfor %}
-    </section>
+.faq-item:hover { border-color: #c8cdd3; }
+
+.faq-item[open] {
+    border-color: #7CBB00;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.07);
+}
+
+.faq-question {
+    list-style: none;
+    cursor: pointer;
+    position: relative;
+    padding: 1rem 3rem 1rem 1.25rem;
+    font-weight: 600;
+    color: #212529;
+}
+
+.faq-question::-webkit-details-marker { display: none; }
+
+/* Chevron */
+.faq-question::after {
+    content: '';
+    position: absolute;
+    right: 1.35rem;
+    top: 50%;
+    width: 9px;
+    height: 9px;
+    border-right: 2px solid #7CBB00;
+    border-bottom: 2px solid #7CBB00;
+    transform: translateY(-70%) rotate(45deg);
+    transition: transform 0.2s;
+}
+
+.faq-item[open] > .faq-question::after {
+    transform: translateY(-30%) rotate(225deg);
+}
+
+.faq-answer {
+    padding: 0 3rem 1.1rem 1.25rem;
+    color: #495057;
+}
+
+.faq-answer p:last-child { margin-bottom: 0; }
+
+.faq-category { scroll-margin-top: 95px; }
+
+.faq-category-title {
+    border-bottom: 2px solid #7CBB00;
+    display: inline-block;
+    padding-bottom: 0.35rem;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    html { scroll-behavior: smooth; }
+}
+</style>
+
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-lg-9">
+
+            <div class="text-center mb-4">
+                <h1 class="display-4 editable">Frequently Asked Questions</h1>
+                <p class="lead text-muted editable">Everything you need to know about Process PA. Can't find what you're after? Chat with us or email <a href="mailto:support@processpa.com">support@processpa.com</a>.</p>
+            </div>
+
+            <div class="mb-3">
+                <input type="search" id="faq-search" class="form-control form-control-lg" placeholder="Search questions&hellip;" aria-label="Search frequently asked questions">
+            </div>
+
+            <nav class="nav nav-pills justify-content-center mb-2" aria-label="FAQ categories">
+                {% for cat in page.faq_categories %}
+                <a class="nav-link py-1 px-3 m-1 border rounded-pill" href="#{{ cat.id }}">{{ cat.title }}</a>
+                {% endfor %}
+            </nav>
+
+            <div class="text-right mb-4">
+                <button type="button" class="btn btn-sm btn-link text-muted" id="faq-expand-all">Expand all</button>
+                <button type="button" class="btn btn-sm btn-link text-muted" id="faq-collapse-all">Collapse all</button>
+            </div>
+
+            {% for cat in page.faq_categories %}
+            <section class="faq-category mb-5" id="{{ cat.id }}">
+                <h2 class="h4 faq-category-title mb-3">{{ cat.title }}</h2>
+                {% assign items = page.faq | where: "category", cat.id %}
+                {% for item in items %}
+                <details class="faq-item" id="{{ item.question | slugify }}">
+                    <summary class="faq-question">{{ item.question }}</summary>
+                    <div class="faq-answer">{{ item.answer | markdownify }}</div>
+                </details>
+                {% endfor %}
+            </section>
+            {% endfor %}
+
+            <p class="text-center text-muted" id="faq-no-results" hidden>No questions match your search. Try different words, or <a href="mailto:support@processpa.com">ask us directly</a>.</p>
+
+            <div class="bg-light rounded p-4 p-md-5 text-center mt-5">
+                <h2 class="h4 editable">Still have questions?</h2>
+                <p class="text-muted mb-4 editable">Browse the help documentation, or see for yourself with a free 30-day trial — no credit card required.</p>
+                <a class="btn btn-outline-info mx-2 mb-2" href="/help.html">Browse Help Docs</a>
+                <a class="btn btn-success mx-2 mb-2" href="https://app.processpa.com/authenticate/password-register">Start 30-Day Trial</a>
+            </div>
+
+        </div>
+    </div>
 </div>
+
+<script>
+(function () {
+    var items = Array.prototype.slice.call(document.querySelectorAll('.faq-item'));
+    var categories = Array.prototype.slice.call(document.querySelectorAll('.faq-category'));
+    var search = document.getElementById('faq-search');
+    var noResults = document.getElementById('faq-no-results');
+
+    search.addEventListener('input', function () {
+        var query = search.value.trim().toLowerCase();
+        var anyVisible = false;
+
+        items.forEach(function (item) {
+            var match = !query || item.textContent.toLowerCase().indexOf(query) !== -1;
+            item.hidden = !match;
+            if (match) {
+                anyVisible = true;
+                if (query.length >= 2) item.open = true;
+            }
+        });
+
+        categories.forEach(function (section) {
+            section.hidden = !section.querySelector('.faq-item:not([hidden])');
+        });
+
+        noResults.hidden = anyVisible;
+    });
+
+    document.getElementById('faq-expand-all').addEventListener('click', function () {
+        items.forEach(function (item) { if (!item.hidden) item.open = true; });
+    });
+
+    document.getElementById('faq-collapse-all').addEventListener('click', function () {
+        items.forEach(function (item) { item.open = false; });
+    });
+
+    // Deep links (#slug) should land on an already-opened answer
+    function openFromHash() {
+        if (!location.hash) return;
+        var target = document.getElementById(location.hash.slice(1));
+        if (target && target.classList.contains('faq-item')) target.open = true;
+    }
+    window.addEventListener('hashchange', openFromHash);
+    openFromHash();
+})();
+</script>


### PR DESCRIPTION
## Summary

Redesigns `faq.html` into a modern, scannable help page and refreshes the question set for relevance and completeness.

### Layout & UX
- Questions are now grouped into **five categories** (Getting Started, Pricing & Billing, Members & Access, Meetings/Agendas/Minutes, Documents/Data/Security) ordered by what a prospect or new user asks first — instead of one flat 30-item list.
- Each answer is a **collapsible card** built on the native `<details>`/`<summary>` element, so **multiple answers can be open at once** and the page stays skimmable. No JS is needed for open/close.
- **Client-side search box** filters questions as you type (auto-expanding matches and hiding empty categories), plus **Expand all / Collapse all** controls and a category pill nav that jumps to sections.
- Brand-green accents, hover states and an animated chevron; fully responsive and mobile-friendly. A "Still have questions?" CTA block links to Help docs and the free trial.

### Content
- **Added missing questions**: pricing/plans, NFP discount, annual billing, sub-committees, data security, data export, moving documents, and how to get support.
- **Fixed an outdated answer**: documents *can* now be moved/renamed between folders (old copy said they couldn't), pointing to the relevant help article.
- **Merged/trimmed** narrow or duplicated entries (e.g. per-feature agenda-font and clock-reset trivia) and tightened wording throughout; corrected the trial length reference to the 30-day free trial.

### Technical notes
- Switched from `layout: page` to `layout: standard` to give the hero/search full width control; heading and intro remain `editable` for CloudCannon.
- FAQ content stays in front matter (`faq:` + new `faq_categories:`), so the existing `schema-faq.html` include still emits valid **FAQPage** JSON-LD — verified all 30 Q&As render into the schema.
- One small vanilla-JS IIFE handles search / expand-collapse / deep-linking (`#slug` anchors still open the target answer), consistent with the site's minimal-JS approach.

### Verification
- `bundle exec jekyll build` completes cleanly.
- Rendered in Chromium at desktop and mobile widths; confirmed categories, multi-open answers, live search filtering, and JSON-LD output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DZkFD7YQSPz9kwrv1uTwj

---
_Generated by [Claude Code](https://claude.ai/code/session_019DZkFD7YQSPz9kwrv1uTwj)_