### PR TITLE
🐛 fix: deploy PR builds to a fixed QA URL via SWA CLI

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -32,19 +32,14 @@ jobs:
           JEKYLL_ENV: production
           JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Pull requests land on the QA app's "qa" named environment, which keeps a
-      # stable URL across PRs rather than the per-PR staging URL SWA defaults to.
+      # Pull requests go to the QA app on one fixed URL. The deploy action would
+      # override any environment with the PR number, so use the SWA CLI, which
+      # honours --env, and target the QA app's own production environment.
       - name: Deploy to QA
         if: github.event_name == 'pull_request'
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_QA }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          action: upload
-          app_location: _site
-          skip_app_build: true
-          skip_api_build: true
-          deployment_environment: qa
+        env:
+          SWA_CLI_DEPLOYMENT_TOKEN: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_QA }}
+        run: npx --yes @azure/static-web-apps-cli@2 deploy _site --env production
 
       - name: Deploy to production
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'


### PR DESCRIPTION
Makes PR builds publish to the QA static site at a single stable URL.

`Azure/static-web-apps-deploy@v1` overrides the target environment with the PR number on `pull_request` events, so PR builds landed on `...-23.eastasia...` and the QA app's default hostname stayed empty (`WaitingForDeployment`). The SWA CLI honours `--env`, so the QA step now publishes to the QA app's production environment.

**Flow after merge**
- PR → `ProcessPAMarketingSiteQA` (`ppa-qa-mpn`, Microsoft Partner Network) → https://gentle-water-0c7874300.7.azurestaticapps.net
- `master` → `ProcessPAMarketingSite` (`PPA-Prod`) → https://proud-sand-05735ce00.7.azurestaticapps.net

Verified: run 29067036997 deployed this branch to the QA hostname, which now returns 200 serving the Process PA homepage.

Contains two empty commits from trigger testing — **squash merge** to keep them out of history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrwcjgR7kBuh2KMPgi9Nvo