### PR TITLE
⬆️ fix: bump ffi to 1.17.4 so bundle install resolves again

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -13,10 +13,6 @@ on:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
-    env:
-      # Same as Dockerfile.jekyll: the lock's ffi platform entries predate the
-      # x86_64-linux-gnu split on rubygems.org, so build native gems from source
-      BUNDLE_FORCE_RUBY_PLATFORM: 'true'
     steps:
       - uses: actions/checkout@v4
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,10 +48,7 @@ GEM
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
-    ffi (1.17.2)
-    ffi (1.17.2-x64-mingw-ucrt)
-    ffi (1.17.2-x64-unknown)
-    ffi (1.17.2-x86_64-linux)
+    ffi (1.17.4)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     github-pages (232)


### PR DESCRIPTION
Fixes the CloudCannon build failure.

rubygems yanked the precompiled `ffi 1.17.2` Linux binaries (`ffi-1.17.2-x86_64-linux.gem` → 403) while keeping the source gem (`ffi-1.17.2.gem` → 200). CloudCannon resolves the precompiled variant and fails; GitHub Actions kept passing only because it set `BUNDLE_FORCE_RUBY_PLATFORM=true`, which compiles from source instead.

Bumping the lockfile to `ffi 1.17.4` (published for all platforms) fixes resolution in both places, so the CI workaround and its now-inaccurate comment are removed.

**Verified** with a clean `bundle install` on `ruby:3.2-slim` (the version CloudCannon uses) with no overrides:
```
EXIT=0
Installing ffi 1.17.4 with native extensions
Bundle complete! 6 Gemfile dependencies, 101 gems now installed.
```

The CI run on this PR is the check that dropping `BUNDLE_FORCE_RUBY_PLATFORM` is safe. QA preview: https://gentle-water-0c7874300.7.azurestaticapps.net

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrwcjgR7kBuh2KMPgi9Nvo