### PR TITLE
📝 Document shipped features from Product Updates into help + FAQ fix

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -73,7 +73,7 @@ faq:
     answer: Yes. When the agenda is emailed, a link is included where members can click and record their attendance for the meeting.
   - category: meetings
     question: Do the previous meeting's minutes automatically appear on the next agenda?
-    answer: Yes. Before a meeting can close, a date for the next meeting must be set. The minutes are then automatically included on the agenda for that next meeting.
+    answer: "You no longer have to schedule the next meeting before finalising the current one. When you prepare the next meeting, you choose which unconfirmed minutes to include — this adds a Confirm Minutes motion and links the previous minutes to the agenda. Outstanding actions and motions are surfaced automatically as business arising, and you pick which to carry forward. See [Confirm minutes and business arising](/help/meetings/confirm%20previous%20minutes)."
   - category: meetings
     question: Can minutes be edited once a meeting is finalised?
     answer: Minutes from completed meetings can be edited and redistributed; however, new action items and/or motions cannot be created. Please contact [support@processpa.com](mailto:support@processpa.com) if you need help with this.

--- a/help.html
+++ b/help.html
@@ -41,6 +41,11 @@ help_topics:
     summary: Request a password reset link by email and choose a new password. For your security, Process PA never reveals whether an email address has an account.
     keywords: forgot password reset forgotten link email recover account locked out
   - category: getting-started
+    title: Two-factor authentication
+    link: help/onboarding/two-factor%20authentication
+    summary: Add a second layer of security to your login with a one-time code sent by SMS or email. Available to all customers, and often required by enterprise and government organisations.
+    keywords: two factor authentication 2fa mfa security code sms email one time login verification
+  - category: getting-started
     title: Create an organisation and committee
     link: help/onboarding/create%20an%20organization%20and%20committee
     summary: Set up your organisation (tenant) and its first committee — enter the name, choose a time zone, language and agenda template, and land on your home dashboard.
@@ -75,8 +80,8 @@ help_topics:
   - category: members
     title: Edit and manage members
     link: help/members/edit%20member%20details
-    summary: Update a member's personal details, change their access level, and show or hide no-access members in the list. Note the 100 active-member limit and how email-only members are treated.
-    keywords: edit member details manage show hide no access active member limit 100 register
+    summary: Update a member's personal details, tags, role history and attachments; change their access level; email members; and show or hide no-access members. Note the 100 active-member limit.
+    keywords: edit member details manage show hide no access active member limit 100 register tags role terms history attachments phone address notes email members bcc
   - category: members
     title: Access levels and roles
     link: help/members/access%20levels%20and%20roles
@@ -104,6 +109,16 @@ help_topics:
     link: help/workspace/actions
     summary: The Actions page lists all action items and lets you create a new action to keep tasks moving between meetings.
     keywords: actions action items tasks todo create track follow up
+  - category: workspace
+    title: Circular motions (vote out of session)
+    link: help/meetings/circular%20motions
+    summary: Approve a decision between meetings. Send a circular motion (flying minute) by email; members vote For, Against or Abstain, and Process PA records the confidential result.
+    keywords: circular motion flying minute out of session vote voting resolution decision poll for against abstain 248a
+  - category: workspace
+    title: Using Lite mode
+    link: help/workspace/lite%20mode
+    summary: A streamlined view for directors — quick access to upcoming meetings, board papers, agendas and assigned actions at app.processpa.com/lite.
+    keywords: lite mode director board papers quick view upcoming meetings actions mobile read only
 
   # --- Meetings ---
   - category: meetings
@@ -204,6 +219,11 @@ help_topics:
     summary: Add or delete action items and motions on any agenda item to capture decisions and tasks as they happen.
     keywords: agenda item action item motion add delete create remove decision task
   - category: agendas
+    title: Assign and complete action items
+    link: help/meetings/assign%20and%20complete%20action%20items
+    summary: Assign an action to one or more members or a sub-committee, email reminders for outstanding actions, let assignees complete them from the email, and cancel actions that are no longer needed.
+    keywords: assign action assignee multiple members sub-committee reminder complete email cancel outstanding due
+  - category: agendas
     title: Allot time to an agenda item
     link: help/meetings/allot%20time%20to%20an%20agenda%20item
     summary: Assign an amount of time to an agenda item to keep your meeting running to schedule.
@@ -214,6 +234,11 @@ help_topics:
     summary: Attach a supporting document to an agenda item so it travels with the agenda and its distribution.
     keywords: attach document agenda item file supporting paper upload link
   - category: agendas
+    title: Discussion and private notes
+    link: help/meetings/discussion%20and%20private%20notes
+    summary: Collaborate around a meeting with shared Discussion on agenda items, minutes and attachments, and add Private Notes that only you can see.
+    keywords: discussion comments chat collaborate private notes annotate agenda attachments before during after meeting
+  - category: agendas
     title: Mark attendance and apologies
     link: help/meetings/assign%20attendance%20and%20apology%20responses
     summary: Record each member as attending or an apology, and confirm attendance for the meeting.
@@ -221,8 +246,8 @@ help_topics:
   - category: agendas
     title: Confirm minutes and business arising
     link: help/meetings/confirm%20previous%20minutes
-    summary: Confirm the minutes of a previous meeting, and see how outstanding items carry over automatically as business arising.
-    keywords: confirm minutes previous business arising carry over outstanding items follow up
+    summary: Confirm the minutes of a previous meeting, and choose which outstanding actions and motions to carry forward as business arising. Scheduling the next meeting is no longer required to finalize.
+    keywords: confirm minutes previous business arising carry forward carry over outstanding items follow up unconfirmed next meeting
   - category: agendas
     title: Preview and download the PDF
     link: help/meetings/preview%20and%20download%20pdf
@@ -310,8 +335,8 @@ help_topics:
   - category: distribution
     title: Agenda and minutes attachments
     link: help/meetings/email%20attachments
-    summary: Agenda emails carry the agenda PDF, a calendar (.ics) invite and a ZIP pack of attached documents. Minutes emails carry the minutes PDF — each matching the on-screen preview.
-    keywords: attachment agenda pdf minutes calendar ics invite zip pack documents email
+    summary: Agenda emails carry the agenda PDF, a calendar (.ics) invite and a ZIP pack of attached documents; minutes emails carry the minutes PDF. Control what's sent and the 30 MB limit, or send a secure link instead.
+    keywords: attachment agenda pdf minutes calendar ics invite zip pack documents email size limit 30mb secure link settings board pack bookmarks
   - category: distribution
     title: View the email history
     link: help/meetings/email%20history
@@ -330,6 +355,11 @@ help_topics:
     summary: If you belong to more than one organisation, switch between them easily. You only ever see the organisations you belong to.
     keywords: switch organisation organization tenant multi-tenancy change belong isolation
   - category: settings
+    title: Sub-committees
+    link: help/settings/sub-committees
+    summary: Run finance, risk or working groups as sub-committees under one organisation — each with its own members, meetings and documents — and optionally give parent-committee members view access.
+    keywords: sub-committee subcommittee sub committee working group finance risk hierarchy parent access create switch
+  - category: settings
     title: Edit the committee name
     link: help/settings/committee%20name
     summary: Rename your committee in general settings.
@@ -344,6 +374,16 @@ help_topics:
     link: help/settings/copy%20meeting%20template
     summary: Copy an existing meeting template to reuse a proven agenda structure for a new meeting type.
     keywords: copy template meeting agenda reuse duplicate settings
+  - category: settings
+    title: Customise your agenda & minutes
+    link: help/settings/report%20options
+    summary: Control how agendas and minutes look — page header and letterhead, committee logo, inline or summary tables for actions and motions, attendance sort order, and custom action/motion numbering.
+    keywords: report options pdf letterhead page header logo summary tables inline attendance sort order numbering custom format branding
+  - category: settings
+    title: Export your data
+    link: help/settings/export%20your%20data
+    summary: Export your members, motions and action items as CSV files that open in Excel or Google Sheets — handy for reporting or your auditor. Your records are always yours.
+    keywords: export csv download data members motions actions excel spreadsheet auditor backup
   - category: settings
     title: Who can do what — permissions
     link: help/settings/permissions

--- a/help/meetings/assign and complete action items.md
+++ b/help/meetings/assign and complete action items.md
@@ -1,0 +1,39 @@
+---
+title: Assign and complete action items
+layout: markdown-page
+---
+## Overview
+
+Action items are how work gets done between meetings. Process PA lets you assign an action to one or more people — or to a whole sub-committee — notify them automatically, and let them mark it complete straight from their email. This guide covers assigning, chasing and closing off actions.
+
+## Assign an action
+
+1. Open the action item on its agenda item.
+2. In the **Assigned To** field, choose one or more members. Start typing to filter, or click to select from the list.
+3. You can also assign to a **sub-committee** as the assignee.
+4. Save. Assignees are shown inline during the meeting and in the outstanding actions on the Schedule.
+
+When the meeting ends, each assignee is emailed their action. Actions assigned to a sub-committee are emailed to that sub-committee's members, copied into the sub-committee with a link back to the original, and added to its carry-forward list.
+
+## Complete an action from email
+
+The notification email includes a link that lets the assigned member mark the action **complete** directly — no need to log in and find it.
+
+## Send a reminder for outstanding actions
+
+1. Open the **Outstanding Actions** section.
+2. Select **Send** to email the assignees of all open actions a reminder.
+3. Confirm in the dialog to send.
+
+## Cancel an action
+
+If an action is no longer needed, set its status to **Cancelled**. This keeps it in the minutes as a clear record that it was raised, while marking it as no longer active — it isn't deleted.
+
+## Related
+
+- [Add action items and motions](/help/meetings/add%20action%20items%20and%20motions)
+- [Track action items](/help/workspace/actions)
+- [Sub-committees](/help/settings/sub-committees)
+
+#### Page Details
+Updated on July 17th, 2026

--- a/help/meetings/circular motions.md
+++ b/help/meetings/circular motions.md
@@ -1,0 +1,37 @@
+---
+title: Circular motions (vote out of session)
+layout: markdown-page
+---
+## Overview
+
+Sometimes a decision can't wait for the next meeting. A **circular motion** — also known as a flying minute, circular resolution or out-of-session vote — lets your committee approve a decision by email between meetings. Members vote **For**, **Against** or **Abstain** with a single click, and Process PA records the result for you.
+
+Rules for out-of-session decisions vary between organisations (section 248A of the Corporations Act is a replaceable rule). Always check your own constitution to confirm a circular motion satisfies your requirements.
+
+## Create and send a circular motion
+
+1. Go to the **Motions** page and select **New**.
+2. Complete the motion's **Title** and **Description**, and add any **attachments**.
+3. Set the **voting close time**.
+4. Choose who to send it to — all members or a subset — and add an optional message.
+5. Select **Send**. The motion is emailed to the chosen members.
+
+## How members vote
+
+- Each recipient sees the motion detail in the email and selects **For**, **Against** or **Abstain**.
+- Clicking their choice records the vote and shows a confirmation.
+
+## Monitor and close the vote
+
+1. Watch the voting status on the motion. You can see **who has voted**, but not how they voted — individual votes remain confidential.
+2. When voting is complete, **Close** the voting. If you close before everyone has voted, a warning is shown.
+3. Once closed, the results are revealed.
+4. Set the resulting **Status** of the motion according to your rules — for example, a simple majority or a required percentage.
+
+## Related
+
+- [View motions](/help/workspace/motions)
+- [Add action items and motions](/help/meetings/add%20action%20items%20and%20motions)
+
+#### Page Details
+Updated on July 17th, 2026

--- a/help/meetings/confirm previous minutes.md
+++ b/help/meetings/confirm previous minutes.md
@@ -4,25 +4,30 @@ layout: markdown-page
 ---
 ## Overview
 
-Most meetings begin by confirming the minutes of the previous meeting and reviewing outstanding items. Process PA handles both automatically, so the continuity between meetings is built in.
+Most meetings begin by confirming the minutes of the previous meeting and reviewing outstanding items. Process PA keeps the continuity between meetings clear, while leaving you in control of exactly what carries forward.
 
 ## Confirm the previous minutes
 
-1. Before a meeting can close, a date for the next meeting must be set. The minutes of the meeting you're closing are then automatically included on that next agenda.
-2. At the next meeting, open the agenda item for confirming the previous minutes.
+You don't have to schedule the next meeting to finalize the current one — that requirement was removed. Instead, when you prepare the next meeting, you choose which previous minutes to include:
+
+1. While preparing the next meeting, select from your **unconfirmed minutes** the ones to include on the agenda. This prepares a *Confirm Minutes* motion and links the previous minutes directly to the agenda.
+2. At the meeting, open the confirm-minutes agenda item.
 3. Record that the minutes were confirmed.
 
-## Business arising (carry-over)
+## Business arising (Carry Forward)
 
-Outstanding action items and unfinished business from prior meetings appear automatically as **business arising** on the next agenda. You don't have to copy anything across — items stay visible until they're resolved.
+Outstanding action items and motions from prior meetings are surfaced automatically as **business arising** — a yellow exclamation mark (**!**) flags when there's something to carry forward, so nothing is overlooked.
 
-1. Review the business arising items on the agenda.
-2. Update, complete or add notes to each as the meeting progresses.
+1. When preparing the agenda, review the outstanding items and **choose which to carry forward** onto this meeting. You decide what's still relevant rather than having everything copied across.
+2. During the meeting, update, complete or add notes to each carried-forward item.
+
+Carried-over actions and motions keep their original numbers, so they're easy to track from one meeting to the next.
 
 ## Related
 
 - [Configure the next meeting](/help/meetings/configure%20the%20next%20meeting)
 - [Track action items](/help/workspace/actions)
+- [Assign and complete action items](/help/meetings/assign%20and%20complete%20action%20items)
 
 #### Page Details
-Updated on July 16th, 2026
+Updated on July 17th, 2026

--- a/help/meetings/discussion and private notes.md
+++ b/help/meetings/discussion and private notes.md
@@ -1,0 +1,36 @@
+---
+title: Discussion and private notes
+layout: markdown-page
+---
+## Overview
+
+Process PA lets you collaborate around a meeting without leaving the platform. **Discussion** is a shared conversation on a meeting or attachment, while **Private Notes** are your own annotations that only you can see. Both are available to logged-in Normal and Administrator members, before, during and after a meeting.
+
+## Discussion (shared)
+
+Use Discussion to talk through agenda items, minutes or attachments as a group.
+
+1. Open a meeting's **agenda** or **minutes** in Edit or Preview, or open an attachment.
+2. Open the Discussion area and add a comment.
+3. Other logged-in members can read and reply, keeping the conversation attached to the relevant item.
+
+## Private Notes (just for you)
+
+Private Notes sit alongside Discussion and are visible only to you — perfect for following along in a meeting.
+
+1. Open the Discussion/Notes area on the agenda or an attachment.
+2. Choose the agenda item from the drop-down at the top, or open the agenda item directly.
+3. Add your note. As you reach that item or attachment during the meeting, your notes are right there.
+
+## Good to know
+
+- Discussion and Private Notes are available to Normal and Administrator members — Email-only members don't log in, so they don't have access.
+- Use Discussion to reduce back-and-forth email threads and keep decisions in context.
+
+## Related
+
+- [Attach a document to an agenda item](/help/meetings/attach%20a%20document%20to%20an%20agenda%20item)
+- [Preview a meeting](/help/meetings/preview%20the%20selected%20meeting)
+
+#### Page Details
+Updated on July 17th, 2026

--- a/help/meetings/email attachments.md
+++ b/help/meetings/email attachments.md
@@ -22,15 +22,24 @@ When you email an agenda or minutes from Process PA, the right attachments are b
 2. Preview the agenda or minutes to check it reads correctly. See [Preview and download the PDF](/help/meetings/preview%20and%20download%20pdf).
 3. Send the agenda or minutes. The PDF, calendar invite and document ZIP (for agendas) are attached automatically.
 
+## Control what gets attached
+
+You decide how much is sent. In **Settings** you can choose whether an email includes the PDF agenda or minutes, the attachments, or both.
+
+- Before sending, Process PA shows the attachments and their total size, so you can see how large the email will be.
+- There is a **30 MB** limit — many mailboxes reject emails larger than this. If your attachments are getting big, switch the setting to send a **secure link** instead. Members click through and log in to view or download the documents, rather than receiving them as attachments.
+
 ## Good to know
 
 - Because everything a member needs arrives by email, they get the full benefit of Process PA without logging in.
 - The attached PDF always reflects the latest preview, so recipients and your on-screen copy stay in sync.
+- Attached PDFs are combined into a single board pack with bookmarks, so recipients can jump straight to each attachment.
 
 ## Related
 
 - [Send the agenda](/help/meetings/send%20the%20agenda)
 - [Send the minutes](/help/meetings/send%20the%20minutes)
+- [Customise your agenda & minutes](/help/settings/report%20options)
 
 #### Page Details
-Updated on July 16th, 2026
+Updated on July 17th, 2026

--- a/help/members/edit member details.md
+++ b/help/members/edit member details.md
@@ -13,6 +13,26 @@ This guide covers keeping your member list up to date — editing a member's per
 3. Update their name, email, access level or committee role.
 4. Save your changes.
 
+Members can also update their own personal details once they're logged in.
+
+## What the member register holds
+
+The Members register is a full record for each person, not just a name and email:
+
+- **Personal details** — phone, date of birth and address, plus a free-text **Notes** field for anything else (skills, availability, reason for leaving).
+- **Tags** — label members to suit your organisation, for example *Parent / Staff / Community*, *Paid / Volunteer*, or *Ordinary / Voting / Life Member*.
+- **Role terms** — record the role a member held and the period they held it, keeping a full history of your committee. The current role shows on the Members list.
+- **Attachments** — store documents against a member, such as ID copies, blue-card or police checks, or signed membership forms.
+
+## Email your members
+
+From the Members page, administrators can email members using their own email application:
+
+- Select **Email** to add all members to the **BCC** field of a new email.
+- Or click an individual member's address to start an email to just that person.
+
+Member email addresses are only visible to Administrators — Normal and Email-only members don't see them.
+
 ## Show or hide no-access members
 
 Members set to **No-access** remain in your records but can't sign in. To keep the list tidy you can show or hide them:

--- a/help/onboarding/two-factor authentication.md
+++ b/help/onboarding/two-factor authentication.md
@@ -1,0 +1,27 @@
+---
+title: Two-factor authentication
+layout: markdown-page
+---
+## Overview
+
+Two-factor authentication (2FA) adds a second layer of security to your login. As well as your password, you enter a one-time code sent to you — so even if someone learns your password, they can't sign in without the code. 2FA is available to all Process PA customers and is often required by enterprise and government organisations.
+
+## How it works
+
+1. Enter your email and password at [https://app.processpa.com/](https://app.processpa.com/) as usual.
+2. Request a one-time code to be sent to you by **SMS** or **email**.
+3. Enter the code to complete your login.
+
+## Good to know
+
+- Process PA has undergone independent security and penetration testing, including for a large government department — 2FA is part of keeping your records safe.
+- If you don't receive your code, check your phone signal or your email junk folder, and make sure you [trust the email sender](/help/trust-email-sender).
+- For help enabling 2FA across your organisation, contact [support@processpa.com](mailto:support@processpa.com).
+
+## Related
+
+- [Log in to Process PA](/help/onboarding/log%20in)
+- [Who can do what — permissions](/help/settings/permissions)
+
+#### Page Details
+Updated on July 17th, 2026

--- a/help/settings/export your data.md
+++ b/help/settings/export your data.md
@@ -1,0 +1,34 @@
+---
+title: Export your data
+layout: markdown-page
+---
+## Overview
+
+Your records are always yours. As well as keeping everything in one place online, Process PA lets you export key registers as **CSV** files (comma-separated values) that open directly in Excel or Google Sheets — handy for reporting, sharing with your auditor, or keeping an offline copy.
+
+## What you can export
+
+- **Members** — export the member register from the Members page.
+- **Motions** — export the motions register.
+- **Actions** — export action items from the Actions list on the Schedule screen.
+
+Each export downloads as a CSV file you can open in your spreadsheet application.
+
+## How to export
+
+1. Open the relevant page — **Members**, **Motions** or **Actions**.
+2. Choose the **Export** option.
+3. Save the CSV file, then open it in Excel or Google Sheets.
+
+## Good to know
+
+- Alongside CSV exports, you can download agendas, minutes and documents as PDFs and files at any time — you're never locked in.
+- Exporting doesn't remove anything from Process PA; it simply gives you a copy.
+
+## Related
+
+- [Preview and download the PDF](/help/meetings/preview%20and%20download%20pdf)
+- [Download multiple files](/help/documents/download%20multiple%20files)
+
+#### Page Details
+Updated on July 17th, 2026

--- a/help/settings/report options.md
+++ b/help/settings/report options.md
@@ -1,0 +1,33 @@
+---
+title: Customise your agenda & minutes
+layout: markdown-page
+---
+## Overview
+
+Boards and committees differ in what they like to see on their agendas and minutes. Process PA gives you control over how these generated reports look and what they include, all from the **Settings** page.
+
+## Report options
+
+Open **Settings** to adjust:
+
+- **Page header / letterhead** — include your organisation's full page header so agendas and minutes look striking and on-brand.
+- **Committee logo** — upload your logo; it appears in place of the default and on your organisation tiles.
+- **Actions & motions layout** — choose whether actions and motions appear **inline**, in **summary tables** at the end, or **both**.
+- **Attendance sort order** — list attendees and apologies in default, first-name or last-name order.
+- **Footer detail** — generated PDFs show *page X of Y* and a last-modified stamp so recipients know they have the current version.
+
+## Custom numbering for actions and motions
+
+You can set how action items and motions are numbered so they're easy to identify across meetings. A number is made of up to three parts — **Prefix**, **Date** (none, day, month or year) and **Count** (global, per year, or per meeting). For example, prefix `A`, date `Year` and count `Year` produces `A-17-008`. Numbers are calculated at the end of the meeting, and carried-over items keep their number.
+
+## Default meeting name and location
+
+In the agenda template area of Settings you can set a default **name** and **location** for each meeting type, so new meetings start pre-filled.
+
+## Related
+
+- [Copy a meeting template](/help/settings/copy%20meeting%20template)
+- [Agenda and minutes attachments](/help/meetings/email%20attachments)
+
+#### Page Details
+Updated on July 17th, 2026

--- a/help/settings/sub-committees.md
+++ b/help/settings/sub-committees.md
@@ -1,0 +1,35 @@
+---
+title: Sub-committees
+layout: markdown-page
+---
+## Overview
+
+Sub-committees let you run separate groups — a finance sub-committee, a risk sub-committee, a working group — under the one organisation. Each sub-committee has its own members, meetings, minutes and documents, with permissions maintained separately, while sitting in a clear hierarchy beneath the parent committee.
+
+## Create a sub-committee
+
+1. From your organisation's home page, choose to create a new committee.
+2. Give the sub-committee a name and set it up as you would your main committee.
+3. It appears in your organisation's committee hierarchy, ready to use.
+
+Your plan includes a number of sub-committees (the Standard plan includes 2 and Enterprise includes 5); additional ones can be added for a small monthly fee. To adjust your subscription, [contact us](mailto:support@processpa.com).
+
+## Switch between committees
+
+When you're logged in, use the committee hierarchy view to switch quickly between the parent committee and its sub-committees. See [Switch between organisations](/help/settings/switch%20organisations).
+
+## Give the parent committee visibility
+
+By default a sub-committee is private to its own members. If you'd like parent-committee members to be able to view a sub-committee — for example, so every board member can see what a sub-committee is doing — enable the **Allow access to parent committee members** setting on the sub-committee. This grants view access without adding each person as a member.
+
+## Assign actions to a sub-committee
+
+Action items can be assigned to a sub-committee. At the end of a meeting, those actions are emailed to the sub-committee's members, copied into the sub-committee with a link back to the original, and included in its carry-forward list. See [Assign and complete action items](/help/meetings/assign%20and%20complete%20action%20items).
+
+## Related
+
+- [Create an organisation and committee](/help/onboarding/create%20an%20organization%20and%20committee)
+- [Who can do what — permissions](/help/settings/permissions)
+
+#### Page Details
+Updated on July 17th, 2026

--- a/help/workspace/lite mode.md
+++ b/help/workspace/lite mode.md
@@ -1,0 +1,34 @@
+---
+title: Using Lite mode
+layout: markdown-page
+---
+## Overview
+
+Lite mode is a streamlined view built for directors and committee members who just need quick access to their upcoming meeting papers, agendas and assigned actions — without the full editing interface. It's ideal when you're on the go or simply want to catch up on what's ahead.
+
+## What Lite mode shows
+
+- Your **upcoming meetings**.
+- The **papers and agenda** for each meeting.
+- Your **assigned action items**.
+
+Everything is presented clearly and concisely so you can find what you need and get up to speed quickly.
+
+## How to open Lite mode
+
+1. Go to [https://app.processpa.com/lite](https://app.processpa.com/lite).
+2. Log in if prompted.
+3. Browse your upcoming meetings and open the papers, agenda or actions you need.
+
+## Good to know
+
+- Lite mode is read-focused — to prepare agendas, run meetings or take minutes, use the full app at [https://app.processpa.com/](https://app.processpa.com/).
+- It's a great option to recommend to busy board members who mainly need to review board papers before a meeting.
+
+## Related
+
+- [The committee dashboard](/help/workspace/dashboard)
+- [Track action items](/help/workspace/actions)
+
+#### Page Details
+Updated on July 17th, 2026


### PR DESCRIPTION
@
Reviewed all Product Updates posts and folded the shipped, general-availability features into the help centre. Also corrects a now-outdated carry-over claim in both the help and the FAQ.

## New guides (8) — help tiles 62 → 70
- **Getting Started:** Two-factor authentication (one-time code by SMS/email)
- **Committee Workspace:** Circular motions (out-of-session voting); Using Lite mode (`/lite`)
- **Agendas & Minutes:** Assign and complete action items (assign to many / to a sub-committee, email reminders, complete-from-email, cancel status); Discussion and private notes
- **Settings & Organisation:** Sub-committees; Export your data (CSV); Customise your agenda & minutes (report/PDF options)

## Corrections & enrichments
- **confirm previous minutes** + **FAQ:** removed the outdated claim that a next-meeting date must be set before closing (removed in the 2022 Simplified Carry Over update); now describes selecting unconfirmed minutes and explicit **Carry Forward**.
- **email attachments:** control what is sent, the 30 MB limit, secure-link option, combined-PDF board packs.
- **edit/manage members:** member register fields (phone/DOB/address/notes), tags, role terms/history, member attachments, and emailing members.

## Deliberately held (not GA)
Registers (Risk / Conflict of Interest — early-access/progressive rollout), meeting transcription (prototype), and the developer API.

## Verification
- Clean `bundle exec jekyll build` in the Docker container.
- All 70 help tile links verified to resolve to generated pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016C6ThCmMC3WSqX1KMafdKn
@